### PR TITLE
express app init

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -1,0 +1,2 @@
+PORT =8000
+SERVER_DOMAIN=http://localhost

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,10 +12,12 @@
         "bcryptjs": "^2.4.3",
         "cloudinary": "^2.5.1",
         "cookie-parser": "^1.4.7",
+        "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",
-        "mongoose": "^8.9.5",
+        "mongoose": "^8.9.6",
+        "nodemailer": "^6.10.0",
         "socket.io": "^4.8.1"
       },
       "devDependencies": {
@@ -1003,9 +1005,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.9.5",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.9.5.tgz",
-      "integrity": "sha512-SPhOrgBm0nKV3b+IIHGqpUTOmgVL5Z3OO9AwkFEmvOZznXTvplbomstCnPOGAyungtRXE5pJTgKpKcZTdjeESg==",
+      "version": "8.9.6",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.9.6.tgz",
+      "integrity": "sha512-ipLvXwNPVuuuq5H3lnSD0lpaRH3DlCoC6emnMVJvweTwxU29uxDJWxMsNpERDQt8JMvYF1HGVuTK+Id2BlQLCA==",
       "dependencies": {
         "bson": "^6.10.1",
         "kareem": "2.6.3",
@@ -1079,6 +1081,14 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.0.tgz",
+      "integrity": "sha512-SQ3wZCExjeSatLE/HBaXS5vqUOQk6GtBdIIKxiFdmm01mOQZX/POJkO3SUX1wDiYcwUOJwT23scFSC9fY2H8IA==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -2,22 +2,24 @@
   "name": "backend",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
-    "dev" :  "nodemon index.js"
+    "dev": "nodemon index.js"
   },
   "keywords": [],
   "author": "",
-  "type":"module",
+  "type": "module",
   "license": "ISC",
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "cloudinary": "^2.5.1",
     "cookie-parser": "^1.4.7",
+    "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.9.5",
+    "mongoose": "^8.9.6",
+    "nodemailer": "^6.10.0",
     "socket.io": "^4.8.1"
   },
   "devDependencies": {

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,29 @@
+import express from "express"
+import cors from "cors"
+import "dotenv/config"; // this works directly instead of iporting dotenv, then dotenv.config()
+import cookieParser from "cookie-parser";
+
+
+
+const app = express();
+
+
+app.use(express.json());
+app.use(cookieParser());
+app.use(cors({
+    credentials:true,
+}));   
+
+
+app.get('/', (req,res)=>{
+    res.send("root page api response");
+})
+
+
+
+const port = process.env.PORT || 8000;
+const DOMAIN = process.env.SERVER_DOMAIN;
+app.listen(port, ()=>{
+    console.log(`server is running on port ${DOMAIN}:${port}`);
+});
+


### PR DESCRIPTION
- npm install express cors dotenv jsonwebtoken mongoose bcryptjs nodemailer cookie-parser
    - cors: allow connect backend with frontend
    - jsonwebtoken: to create jwt
    - mongoose : to help connect with mongodb
    - bcryptjs: to encrypt
    - nodemailer for OTP
        - cookie-parser: help us send cookie in API
- npm install -D nodemon
    - doing is separately because -D meaning its a development dependency and not needed in production
- using “type”:”module”
- start coding the server.js  (btw rename main entry point to server.js from index.js if that’s what you’re using in package.json)
- added express app, express.json , cookieParser, cors
- added a temporary get response in the root path just to see if its working
- started listening on port 8000